### PR TITLE
Set 'ace-jump-mode-end-hook' to nil when no candidates

### DIFF
--- a/ace-link.el
+++ b/ace-link.el
@@ -72,8 +72,12 @@
            (list (lambda ()
                    (setq ace-jump-mode-end-hook)
                    ,@follower)))
-     (let ((ace-jump-mode-scope 'window))
-       (ace-jump-do ""))))
+     (condition-case err
+         (let ((ace-jump-mode-scope 'window))
+           (ace-jump-do ""))
+       (error
+        (setq ace-jump-mode-end-hook)
+        (signal (car err) (cdr err))))))
 
 ;; ——— Interactive —————————————————————————————————————————————————————————————
 ;;;###autoload


### PR DESCRIPTION
When there is no candidates, the `ace-jump-mode-end-hook' should be set to nil