### PR TITLE
Return correct info link position

### DIFF
--- a/ace-link.el
+++ b/ace-link.el
@@ -97,7 +97,7 @@
   (cons (cl-letf (((symbol-function #'Info-goto-node)
                    (lambda (node _) node)))
           (Info-try-follow-nearest-node))
-        (1- (point))))
+        (point)))
 
 (defun ace-link--info-collect ()
   "Collect the positions of visible links in the current `Info-mode' buffer."


### PR DESCRIPTION
Hi!

I'm not sure about the reasoning behind the `(1- (point))` in `ace-link--info-current`. It results in a met `while` condition in `ace-link--info-collect` for Info pages with only one link (see for example `(info "(elisp) Expansion")`), inevitably running into an infinite loop.