### PR TITLE
Disable automatic opening of http links on info pages

### DIFF
--- a/ace-link.el
+++ b/ace-link.el
@@ -95,7 +95,9 @@
 (defun ace-link--info-current ()
   "Return the node at point."
   (cons (cl-letf (((symbol-function #'Info-goto-node)
-                   (lambda (node _) node)))
+                   (lambda (node _) node))
+                  (browse-url-browser-function
+                   (lambda (url &rest _) url)))
           (Info-try-follow-nearest-node))
         (1- (point))))
 


### PR DESCRIPTION
(I cancelled the last PR and created this one, with a separate branch and a single clean commit.)

I did some debugging on issue #32 and found that the below change solves my problems. It seems that the function `Info-try-follow-nearest-node' automatically opens up URL:s in new browser windows. So I did something similar to your trick of not actually following links, but also for URL:s.

What do you think about this?

(I'm using Emacs version 25.1.1)
