### PR TITLE
Add support for helpful

### DIFF
--- a/ace-link.el
+++ b/ace-link.el
@@ -421,7 +421,10 @@
        (define-key eww-mode-map ,key 'ace-link-eww)))
   (eval-after-load 'cus-edit
     `(progn
-       (define-key custom-mode-map ,key 'ace-link-custom))))
+       (define-key custom-mode-map ,key 'ace-link-custom)))
+  (eval-after-load "helpful"
+    `(progn
+       (define-key helpful-mode-map ,key 'ace-link-help))))
 
 (provide 'ace-link)
 


### PR DESCRIPTION
Helpful is a replacement for *help* buffers that provides much more contextual information. https://melpa.org/#/helpful