### PR TITLE
Add helpful-mode support to ace-link

### DIFF
--- a/ace-link.el
+++ b/ace-link.el
@@ -50,7 +50,7 @@
   (cond ((eq major-mode 'Info-mode)
          (ace-link-info))
         ((member major-mode '(help-mode package-menu-mode geiser-doc-mode elbank-report-mode
-                              elbank-overview-mode slime-trace-dialog-mode))
+                              elbank-overview-mode slime-trace-dialog-mode helpful-mode))
          (ace-link-help))
         ((eq major-mode 'woman-mode)
          (ace-link-woman))


### PR DESCRIPTION
`ace-link-help` works for [helpful](https://github.com/Wilfred/helpful) buffers.