### PR TITLE
Fix handling of single-letter links in eww buffers

### DIFF
--- a/ace-link.el
+++ b/ace-link.el
@@ -301,7 +301,7 @@ looks like manpages with a regular expression."
 
 (defun ace-link--eww-action (pt)
   (when (number-or-marker-p pt)
-    (goto-char (1+ pt))
+    (goto-char pt)
     (eww-follow-link)))
 
 (defun ace-link--eww-collect ()


### PR DESCRIPTION
Prior to this commit, if one tries to follow any single-letter link
(see http://lispworks.com/documentation/HyperSpec/Front/X_Master.htm), the point
ends up one character behind the link itself and `No link under point` message
is shown in minibuffer.