### PR TITLE
Add support for vterm-mode

### DIFF
--- a/ace-link.el
+++ b/ace-link.el
@@ -67,7 +67,7 @@
          (ace-link-gnus))
         ((eq major-mode 'mu4e-view-mode)
          (ace-link-mu4e))
-        ((memq major-mode '(org-mode erc-mode elfeed-show-mode term-mode))
+        ((memq major-mode '(org-mode erc-mode elfeed-show-mode term-mode vterm-mode))
          (ace-link-org))
         ((eq major-mode 'org-agenda-mode)
          (ace-link-org-agenda))


### PR DESCRIPTION
Adding `vterm-mode` to the list of supported modes seems to make ace-link works the same way as `term-mode`, so this would be a nice change to have in order to support [emacs-libvterm](https://github.com/akermu/emacs-libvterm).