### PR TITLE
Fix merging of adjacent URLs in ace-link--eww-collect

### DIFF
--- a/ace-link.el
+++ b/ace-link.el
@@ -304,32 +304,33 @@ looks like manpages with a regular expression."
     (goto-char pt)
     (eww-follow-link)))
 
-(defun ace-link--eww-collect ()
-  "Collect the positions of visible links in the current `eww' buffer."
-  (save-excursion
-    (save-restriction
-      (narrow-to-region
-       (window-start)
-       (window-end))
-      (goto-char (point-min))
-      (let (beg end candidates)
-        (setq end
-              (if (get-text-property (point) 'shr-url)
-                  (point)
-                (text-property-any
-                 (point) (point-max) 'shr-url nil)))
-        (while (setq beg (text-property-not-all
-                          end (point-max) 'shr-url nil))
-          (goto-char beg)
-          (setq end (next-single-property-change (point) 'shr-url nil (point-max)))
-          ;; When link at the end of buffer, end will be set to nil.  Otherwise,
-          ;; set end to the point right after the change.
-          (if (eq end nil)
-              (setq end (point-max))
-            (setq end (1+ end)))
-          (push (cons (buffer-substring-no-properties beg end) beg)
-                candidates))
-        (nreverse candidates)))))
+(save-excursion
+  (save-restriction
+    (narrow-to-region
+     (window-start)
+     (window-end))
+    (goto-char (point-min))
+    (let (beg end candidates)
+      (setq end
+            (if (get-text-property (point) 'shr-url)
+                (point)
+              (text-property-any
+               (point) (point-max) 'shr-url nil)))
+      (while (setq beg (text-property-not-all
+                        end (point-max) 'shr-url nil))
+        (goto-char beg)
+        ;; Skip leading newlines in the next link text.  They make things very
+        ;; ugly when running `ace-link-eww' since the characters to jump to
+        ;; each link will be displayed on the line before its visible text.
+        (skip-chars-forward "\n")
+        (setq beg (point))
+        (setq end (next-single-property-change (point) 'shr-url nil (point-max)))
+        ;; When link at the end of buffer, end will be set to nil.
+        (if (eq end nil)
+            (setq end (point-max)))
+        (push (cons (buffer-substring-no-properties beg end) beg)
+              candidates))
+      (nreverse candidates))))
 
 ;;* `ace-link-w3m'
 ;;;###autoload

--- a/ace-link.el
+++ b/ace-link.el
@@ -314,18 +314,19 @@ looks like manpages with a regular expression."
       (goto-char (point-min))
       (let (beg end candidates)
         (setq end
-              (if (get-text-property (point) 'help-echo)
+              (if (get-text-property (point) 'shr-url)
                   (point)
                 (text-property-any
-                 (point) (point-max) 'help-echo nil)))
+                 (point) (point-max) 'shr-url nil)))
         (while (setq beg (text-property-not-all
-                          end (point-max) 'help-echo nil))
+                          end (point-max) 'shr-url nil))
           (goto-char beg)
-          (setq end (text-property-any
-                     (point) (point-max) 'help-echo nil))
-          ;; When link at the end of buffer, end will be set to nil.
+          (setq end (next-single-property-change (point) 'shr-url nil (point-max)))
+          ;; When link at the end of buffer, end will be set to nil.  Otherwise,
+          ;; set end to the point right after the change.
           (if (eq end nil)
-              (setq end (point-max)))
+              (setq end (point-max))
+            (setq end (1+ end)))
           (push (cons (buffer-substring-no-properties beg end) beg)
                 candidates))
         (nreverse candidates)))))

--- a/ace-link.el
+++ b/ace-link.el
@@ -304,33 +304,39 @@ looks like manpages with a regular expression."
     (goto-char pt)
     (eww-follow-link)))
 
-(save-excursion
-  (save-restriction
-    (narrow-to-region
-     (window-start)
-     (window-end))
-    (goto-char (point-min))
-    (let (beg end candidates)
-      (setq end
-            (if (get-text-property (point) 'shr-url)
-                (point)
-              (text-property-any
-               (point) (point-max) 'shr-url nil)))
-      (while (setq beg (text-property-not-all
-                        end (point-max) 'shr-url nil))
-        (goto-char beg)
-        ;; Skip leading newlines in the next link text.  They make things very
-        ;; ugly when running `ace-link-eww' since the characters to jump to
-        ;; each link will be displayed on the line before its visible text.
-        (skip-chars-forward "\n")
-        (setq beg (point))
-        (setq end (next-single-property-change (point) 'shr-url nil (point-max)))
-        ;; When link at the end of buffer, end will be set to nil.
-        (if (eq end nil)
-            (setq end (point-max)))
-        (push (cons (buffer-substring-no-properties beg end) beg)
-              candidates))
-      (nreverse candidates))))
+(defun ace-link--eww-collect ()
+  "Collect the positions of visible links in the current `eww' buffer."
+  (save-excursion
+    (save-restriction
+      (narrow-to-region
+       (window-start)
+       (window-end))
+      (goto-char (point-min))
+      (let (beg end candidates)
+        (setq end
+              (if (get-text-property (point) 'shr-url)
+                  (point)
+                (text-property-any
+                 (point) (point-max) 'shr-url nil)))
+        (while (setq beg (text-property-not-all
+                          end (point-max) 'shr-url nil))
+          (goto-char beg)
+          ;; Skip leading newlines in the next link text.  They make things very
+          ;; ugly when running `ace-link-eww' since the characters to jump to
+          ;; each link will be displayed on the line before its visible text.
+          (skip-chars-forward "\n")
+          (setq beg (point))
+          ;; Handle the case where a link is all newlines by skipping them.
+          (if (get-text-property (point) 'shr-url)
+              (progn
+                (setq end (next-single-property-change (point) 'shr-url nil (point-max)))
+                ;; When link at the end of buffer, end will be set to nil.
+                (if (eq end nil)
+                    (setq end (point-max)))
+                (push (cons (buffer-substring-no-properties beg end) beg)
+                      candidates))
+            (setq end (point))))
+        (nreverse candidates)))))
 
 ;;* `ace-link-w3m'
 ;;;###autoload


### PR DESCRIPTION
When there was no space between adjacent URLs, the old implementation of
ace-link--eww-collect merged them.  For example, this URL on the Common Lisp
HyperSpec was a problem:

http://www.lispworks.com/documentation/HyperSpec/Front/X_Master.htm

The images at the bottom of the page are links and were all merged by the old
implementation.