### PR TITLE
Add handler for notmuch-show

### DIFF
--- a/ace-link.el
+++ b/ace-link.el
@@ -1032,6 +1032,8 @@ call at PT."
     `(define-key xref--xref-buffer-mode-map ,key 'ace-link-xref))
   (eval-after-load "info"
     `(define-key Info-mode-map ,key 'ace-link-info))
+  (eval-after-load "notmuch"
+    `(define-key notmuch-show-mode-map ,key 'ace-link-notmuch-show))
   (eval-after-load "compile"
     `(define-key compilation-mode-map ,key 'ace-link-compilation))
   (eval-after-load "help-mode"

--- a/ace-link.el
+++ b/ace-link.el
@@ -631,9 +631,9 @@ call at PT."
   (interactive)
   (require 'org)
   (let ((pt (avy-with ace-link-org
-              (avy-process
-               (mapcar #'cdr (ace-link--org-collect))
-               (avy--style-fn avy-style)))))
+               (avy-process
+                (mapcar #'cdr (ace-link--org-collect))
+                (avy--style-fn avy-style)))))
     (ace-link--org-action pt)))
 
 (declare-function org-open-at-point "org")


### PR DESCRIPTION
I'd like to merge the work I've done on [`ace-link-notmuch-show`](https://github.com/zaeph/ace-link-notmuch-show) upstream.

It's frictionless with the rest of the code, but there is a bit of repetition for the `text/html` part which adapted `mu4e`'s functions.  Compare:
https://github.com/abo-abo/ace-link/blob/8214d399efc5d0c2a69504cb74ad8fb14dad3988/ace-link.el#L464-L494
https://github.com/abo-abo/ace-link/blob/5c68efb50a10c5bb8024070b9a8d1befbea36be3/ace-link.el#L558-L583

We could refactor the code to create the appropriate modules, but I'd like to get your green-light, first.