### PR TITLE
Refactor email view

### DIFF
--- a/ace-link.el
+++ b/ace-link.el
@@ -68,7 +68,7 @@
         ((eq major-mode 'mu4e-view-mode)
          (ace-link-mu4e))
         ((eq major-mode 'notmuch-show-mode)
-         (ace-link-notmuch-show))
+         (ace-link-notmuch))
         ((memq major-mode '(org-mode erc-mode elfeed-show-mode term-mode vterm-mode))
          (ace-link-org))
         ((eq major-mode 'org-agenda-mode)
@@ -444,92 +444,9 @@ If EXTERNAL is double prefix, browse in new buffer."
             (push (point) candidates)))
         (nreverse candidates)))))
 
-;;* `ace-link-mu4e'
-;;;###autoload
-(defun ace-link-mu4e ()
-  "Open a visible link in an `mu4e-view-mode' buffer."
-  (interactive)
-  (if (bound-and-true-p mu4e-view-use-gnus)
-      (ace-link-gnus)
-    (let ((pt (avy-with ace-link-mu4e
-                (avy-process
-                 (mapcar #'cdr (ace-link--mu4e-collect))
-                 (avy--style-fn avy-style)))))
-      (ace-link--mu4e-action pt))))
-
-(declare-function shr-browse-url "shr")
-(declare-function mu4e~view-browse-url-from-binding "ext:mu4e-view")
-(declare-function mu4e~view-open-attach-from-binding "ext:mu4e-view")
-
-(defun ace-link--mu4e-action (pt)
-  (when (number-or-marker-p pt)
-    (goto-char (1+ pt))
-    (cond ((get-text-property (point) 'shr-url)
-           (shr-browse-url))
-          ((get-text-property (point) 'mu4e-url)
-           (mu4e~view-browse-url-from-binding))
-          ((get-text-property (point) 'mu4e-attnum)
-           (mu4e~view-open-attach-from-binding)))))
-
-(defun ace-link--mu4e-next-link (pos)
-  (let* ((shr-link-pos (text-property-not-all pos (point-max) 'shr-url nil))
-         (mu4e-link-pos (text-property-not-all pos (point-max) 'mu4e-url nil))
-         (mu4e-att-link-pos (text-property-not-all pos (point-max) 'mu4e-attnum nil))
-         (links (cl-remove-if-not
-                 (lambda (link)
-                   (elt link 1))
-                 (list
-                  (list 'shr-url shr-link-pos)
-                  (list 'mu4e-url mu4e-link-pos)
-                  (list 'mu4e-attnum mu4e-att-link-pos)))))
-
-    (if links
-        (car
-         (sort links (lambda (x y)
-                       (< (elt x 1) (elt y 1)))))
-      nil)))
-
-(defun ace-link--mu4e-end-of-link (link)
-  (or (text-property-any (elt link 1) (point-max) (elt link 0) nil)
-      (point-max)))
-
-(defun ace-link--mu4e-collect ()
-  "Collect the positions of visible links in the current mu4e buffer."
-  (save-excursion
-    (save-restriction
-      (narrow-to-region
-       (window-start)
-       (window-end))
-      (goto-char (point-min))
-      (let (link pos candidates)
-        (setq pos (point))
-        (while (setq link (ace-link--mu4e-next-link pos))
-          (goto-char (elt link 1))
-          (setq pos (ace-link--mu4e-end-of-link link))
-          (push (cons (buffer-substring-no-properties (elt link 1) pos) (elt link 1)) candidates))
-        (nreverse candidates)))))
-
-;;* `ace-link-notmuch-show'
-;;;###autoload
-(defun ace-link-notmuch-show-plain ()
-  "Open a visible link in a `notmuch-show' buffer.
-Only consider the 'text/plain' portion of the buffer."
-  (interactive)
-  (let ((pt (avy-with ace-link-notmuch-show-plain
-              (avy-process
-               (ace-link--notmuch-show-plain-collect)
-               #'avy--overlay-pre))))
-    (when pt
-      (ace-link--notmuch-show-plain-action pt))))
-
-(defun ace-link--notmuch-show-plain-action (pt)
-  "Open link at PT in a `notmuch-show' buffer.
-Only works in 'text/plain'"
-  (goto-char pt)
-  (browse-url-at-point))
-
-(defun ace-link--notmuch-show-plain-collect ()
-  "Collect the positions of visible links in `notmuch-show' buffer.
+;;* Helper functions for `ace-link-mu4e' and `ace-link-notmuch'
+(defun ace-link--email-view-plain-collect ()
+  "Collect the positions of visible links in email-view buffer.
 Only consider the links in 'text/plain'."
   (let (candidates pt)
     (save-excursion
@@ -543,48 +460,32 @@ Only consider the links in 'text/plain'."
           (push pt candidates))))
     (nreverse candidates)))
 
-;;;###autoload
-(defun ace-link-notmuch-show-html ()
-  "Open a visible link in a `notmuch-show' buffer.
-Only consider the 'text/html' portion of the buffer."
-  (interactive)
-  (if (bound-and-true-p mu4e-view-use-gnus)
-      (ace-link-gnus)
-    (let ((pt (avy-with ace-link-mu4e
-                (avy-process
-                 (mapcar #'cdr (ace-link--mu4e-collect))
-                 (avy--style-fn avy-style)))))
-      (ace-link--mu4e-action pt))))
-
-(defun ace-link--notmuch-show-html-action (pt)
-  "Open link at PT in a `notmuch-show' buffer.
-Only works in 'text/html'"
-  (when (number-or-marker-p pt)
-    (when (get-text-property (point) 'shr-url)
-      (shr-browse-url))))
-
-(defun ace-link--notmuch-show-html-next-link (pos)
-  "Find next link from POS in current `notmuch-show' buffer."
+(defun ace-link--email-view-next-link (pos)
+  "Find next link from POS in current email-view buffer."
   (let* ((shr-link-pos (text-property-not-all pos (point-max) 'shr-url nil))
-         (links (cl-remove-if-not
-                 (lambda (link)
-                   (elt link 1))
-                 (list
-                  (list 'shr-url shr-link-pos)))))
-
+         (links (list (list 'shr-url shr-link-pos))))
+    (when (derived-mode-p 'mu4e-view-mode)
+      (let ((mu4e-link-pos (text-property-not-all pos (point-max) 'mu4e-url nil))
+            (mu4e-att-link-pos (text-property-not-all pos (point-max) 'mu4e-attnum nil)))
+        (push (list 'mu4e-url mu4e-link-pos) links)
+        (push (list 'mu4e-attnum mu4e-att-link-pos) links)
+        (setq link (nreverse links))))
+    (setq links (cl-remove-if-not (lambda (link)
+                                    (elt link 1))
+                                  links))
     (if links
         (car
          (sort links (lambda (x y)
                        (< (elt x 1) (elt y 1)))))
       nil)))
 
-(defun ace-link--notmuch-show-html-end-of-link (link)
-  "Return end of LINK at point in current `notmuch-show' buffer."
+(defun ace-link--email-view-end-of-link (link)
+  "Return end of LINK at point in current email-view buffer."
   (or (text-property-any (elt link 1) (point-max) (elt link 0) nil)
       (point-max)))
 
-(defun ace-link--notmuch-show-html-collect ()
-  "Collect the positions of visible links in current `notmuch-show' buffer."
+(defun ace-link--email-view-html-collect ()
+  "Collect positions of visible links in the current email-view buffer."
   (save-excursion
     (save-restriction
       (narrow-to-region
@@ -593,18 +494,85 @@ Only works in 'text/html'"
       (goto-char (point-min))
       (let (link pos candidates)
         (setq pos (point))
-        (while (setq link (ace-link--notmuch-show-html-next-link pos))
+        (while (setq link (ace-link--email-view-next-link pos))
           (goto-char (elt link 1))
-          (setq pos (ace-link--notmuch-show-html-end-of-link link))
+          (setq pos (ace-link--email-view-end-of-link link))
           (push (cons (buffer-substring-no-properties (elt link 1) pos) (elt link 1)) candidates))
         (nreverse candidates)))))
 
+;;* `ace-link-mu4e'
 ;;;###autoload
-(defun ace-link-notmuch-show ()
+(defun ace-link-mu4e ()
+  "Open a visible link in an `mu4e-view-mode' buffer."
+  (interactive)
+  (if (bound-and-true-p mu4e-view-use-gnus)
+      (ace-link-gnus)
+    (let ((pt (avy-with ace-link-mu4e
+                (avy-process
+                 (mapcar #'cdr (ace-link--email-view-html-collect))
+                 (avy--style-fn avy-style)))))
+      (ace-link--mu4e-action pt))))
+
+(declare-function shr-browse-url "shr")
+(declare-function mu4e~view-browse-url-from-binding "ext:mu4e-view")
+(declare-function mu4e~view-open-attach-from-binding "ext:mu4e-view")
+
+(defun ace-link--mu4e-action (pt)
+  "Open link at PT in a `mu4e-view' buffer."
+  (when (number-or-marker-p pt)
+    (goto-char (1+ pt))
+    (cond ((get-text-property (point) 'shr-url)
+           (shr-browse-url))
+          ((get-text-property (point) 'mu4e-url)
+           (mu4e~view-browse-url-from-binding))
+          ((get-text-property (point) 'mu4e-attnum)
+           (mu4e~view-open-attach-from-binding)))))
+
+;;* `ace-link-notmuch'
+;;;###autoload
+(defun ace-link-notmuch-plain ()
+  "Open a visible link in a `notmuch-show' buffer.
+Only consider the 'text/plain' portion of the buffer."
+  (interactive)
+  (let ((pt (avy-with ace-link-notmuch-plain
+              (avy-process
+               (ace-link--email-view-plain-collect)
+               #'avy--overlay-pre))))
+    (when pt
+      (ace-link--notmuch-plain-action pt))))
+
+(defun ace-link--notmuch-plain-action (pt)
+  "Open link at PT in a `notmuch-show' buffer.
+Only works in 'text/plain'"
+  (goto-char pt)
+  (browse-url-at-point))
+
+;;;###autoload
+(defun ace-link-notmuch-html ()
+  "Open a visible link in a `notmuch-show' buffer.
+Only consider the 'text/html' portion of the buffer."
+  (interactive)
+  (if (bound-and-true-p mu4e-view-use-gnus)
+      (ace-link-gnus)
+    (let ((pt (avy-with ace-link-mu4e
+                (avy-process
+                 (mapcar #'cdr (ace-link--email-view-html-collect))
+                 (avy--style-fn avy-style)))))
+      (ace-link--mu4e-action pt))))
+
+(defun ace-link--notmuch-html-action (pt)
+  "Open link at PT in a `notmuch-show' buffer.
+Only works in 'text/html'"
+  (when (number-or-marker-p pt)
+    (when (get-text-property (point) 'shr-url)
+      (shr-browse-url))))
+
+;;;###autoload
+(defun ace-link-notmuch ()
   "Open a visible link in `notmuch-show' buffer.
 Consider both the links in 'text/plain' and 'text/html'."
   (interactive)
-  (let ((match (avy-with ace-link-notmuch-show
+  (let ((match (avy-with ace-link-notmuch
                  (avy-process
                   (ace-link--notmuch-collect)
                   #'avy--overlay-pre))))
@@ -620,11 +588,11 @@ Returns a list of cons \( fn . pt ) where FN is the function to
 call at PT."
   (append
    (mapcar (lambda (x)
-             (cons x #'ace-link--notmuch-show-plain-action))
-           (ace-link--notmuch-show-plain-collect))
+             (cons x #'ace-link--notmuch-plain-action))
+           (ace-link--email-view-plain-collect))
    (mapcar (lambda (x)
-             (cons (cdr x) #'ace-link--notmuch-show-html-action))
-           (ace-link--notmuch-show-html-collect))))
+             (cons (cdr x) #'ace-link--notmuch-html-action))
+           (ace-link--email-view-html-collect))))
 
 ;;* `ace-link-org'
 ;;;###autoload
@@ -1035,7 +1003,7 @@ call at PT."
   (eval-after-load "info"
     `(define-key Info-mode-map ,key 'ace-link-info))
   (eval-after-load "notmuch"
-    `(define-key notmuch-show-mode-map ,key 'ace-link-notmuch-show))
+    `(define-key notmuch-show-mode-map ,key 'ace-link-notmuch))
   (eval-after-load "compile"
     `(define-key compilation-mode-map ,key 'ace-link-compilation))
   (eval-after-load "help-mode"

--- a/ace-link.el
+++ b/ace-link.el
@@ -462,12 +462,10 @@ Only consider the links in 'text/plain'."
 
 (defun ace-link--email-view-next-link (pos &optional mu4e)
   "Find next link from POS in current email-view buffer.
-If MU4E is non-nil, or if the buffer is in `mu4e-view-mode', also
-consider mu4e’s links."
+If MU4E is non-nil, also consider mu4e-links."
   (let* ((shr-link-pos (text-property-not-all pos (point-max) 'shr-url nil))
          (links (list (list 'shr-url shr-link-pos))))
-    (when (or mu4e
-              (derived-mode-p 'mu4e-view-mode))
+    (when mu4e
       (let ((mu4e-link-pos (text-property-not-all pos (point-max) 'mu4e-url nil))
             (mu4e-att-link-pos (text-property-not-all pos (point-max) 'mu4e-attnum nil)))
         (push (list 'mu4e-url mu4e-link-pos) links)

--- a/ace-link.el
+++ b/ace-link.el
@@ -547,8 +547,9 @@ Only consider the 'text/plain' portion of the buffer."
 (defun ace-link--notmuch-plain-action (pt)
   "Open link at PT in a `notmuch-show' buffer.
 Only works in 'text/plain'"
-  (goto-char pt)
-  (browse-url-at-point))
+  (when (number-or-marker-p pt)
+    (goto-char pt)
+    (browse-url-at-point)))
 
 ;;;###autoload
 (defun ace-link-notmuch-html ()


### PR DESCRIPTION
Follow-up to #66.

We're not saving all that many chars, but at least we don't have dups.

I've elected to keep the actions separate in order to prevent a messy flow:
https://github.com/abo-abo/ace-link/blob/29a734f9c9441539842b6153b4be34046d599b4e/ace-link.el#L567-L572
https://github.com/abo-abo/ace-link/blob/31fdcc27230e7c903b2258fa9ae11b3448e3eaf9/ace-link.el#L523-L532

I've also renamed `ace-link-notmuch-show` to `ace-link-notmuch` to follow the pattern set by `ace-link-mu4`.  `email-view` was chosen as a viewer-agnostic category for the helper functions.