### PR TITLE
Improve Gnus support and update for Emacs 27.1

### DIFF
--- a/ace-link.el
+++ b/ace-link.el
@@ -413,13 +413,14 @@ If EXTERNAL is double prefix, browse in new buffer."
 (defun ace-link-gnus ()
   "Open a visible link in a `gnus-article-mode' buffer."
   (interactive)
-  (when (eq major-mode 'gnus-summary-mode)
-    (gnus-summary-widget-forward 1))
-  (let ((pt (avy-with ace-link-gnus
-              (avy-process
-               (ace-link--gnus-collect)
-               (avy--style-fn avy-style)))))
-    (ace-link--gnus-action pt)))
+  (save-selected-window
+    (when (eq major-mode 'gnus-summary-mode)
+      (gnus-summary-widget-forward 1))
+    (let ((pt (avy-with ace-link-gnus
+                (avy-process
+                 (ace-link--gnus-collect)
+                 (avy--style-fn avy-style)))))
+      (ace-link--gnus-action pt))))
 
 (defun ace-link--gnus-action (pt)
   (when (number-or-marker-p pt)

--- a/ace-link.el
+++ b/ace-link.el
@@ -64,7 +64,7 @@
         ((or (member major-mode '(compilation-mode grep-mode))
              (bound-and-true-p compilation-shell-minor-mode))
          (ace-link-compilation))
-        ((eq major-mode 'gnus-article-mode)
+        ((memq major-mode '(gnus-article-mode gnus-summary-mode))
          (ace-link-gnus))
         ((eq major-mode 'mu4e-view-mode)
          (ace-link-mu4e))

--- a/ace-link.el
+++ b/ace-link.el
@@ -415,7 +415,11 @@ If EXTERNAL is double prefix, browse in new buffer."
   (interactive)
   (save-selected-window
     (when (eq major-mode 'gnus-summary-mode)
-      (gnus-summary-widget-forward 1))
+      (if-let ((win (gnus-get-buffer-window gnus-article-buffer 'visible)))
+          (progn
+            (select-window win)
+            (select-frame-set-input-focus (window-frame win)))
+        (user-error "No article window found")))
     (let ((pt (avy-with ace-link-gnus
                 (avy-process
                  (ace-link--gnus-collect)

--- a/ace-link.el
+++ b/ace-link.el
@@ -409,6 +409,13 @@ If EXTERNAL is double prefix, browse in new buffer."
 (declare-function compile-goto-error "compile")
 
 ;;* `ace-link-gnus'
+(defvar gnus-article-buffer)
+(defvar mm-text-html-renderer)
+(declare-function gnus-article-press-button "gnus-art")
+(declare-function gnus-get-buffer-window "gnus-win")
+(declare-function widget-button-press "wid-edit")
+(declare-function widget-forward "wid-edit")
+
 ;;;###autoload
 (defun ace-link-gnus ()
   "Open a visible link in a `gnus-article-mode' buffer."


### PR DESCRIPTION
This should fix #56. In addition I added some ergonomic improvements:
- Allow calling `ace-link` from the summary buffer
- After selecting a link return to the summary buffer (only if it was selected before)
- Do not skip around in the article buffer (previously the equivalent of `forward-button` was called, which would scroll the window if the next button after point was out of view)
- When called from the summary: Do not change the selected article buffer but use the currently opened one

@poulpoulsen Maybe you are interested in giving this a try.

N.B. The last two commits have only been tested with Emacs 27.1, so any feedback from someone still on Emacs 26.3 is appreciated.