### PR TITLE
Use ‘ace-link-eww’ for elfeed-show-mode

### DIFF
--- a/ace-link.el
+++ b/ace-link.el
@@ -57,7 +57,7 @@
          (ace-link-man))
         ((eq major-mode 'woman-mode)
          (ace-link-woman))
-        ((eq major-mode 'eww-mode)
+        ((memq major-mode '(eww-mode elfeed-show-mode))
          (ace-link-eww))
         ((eq major-mode 'w3m-mode)
          (ace-link-w3m))
@@ -71,7 +71,7 @@
         ((eq major-mode 'notmuch-show-mode)
          (ace-link-notmuch))
         ((memq major-mode '(org-mode
-                            erc-mode elfeed-show-mode
+                            erc-mode
                             term-mode vterm-mode
                             eshell-mode
                             telega-chat-mode))


### PR DESCRIPTION
In my setup at least, ‘ace-link-org’ only enables the article
URL to be opened, and ignores links in the body of the article.
‘ace-link-eww’ seems to pick up all links, including the link to
the article itself.