### PR TITLE
Ensure window-end is up-to-date for ace-link-man

### DIFF
--- a/ace-link.el
+++ b/ace-link.el
@@ -252,7 +252,7 @@ we'd miss actual links by only collecting button overlays.
 The workaround for non-button links is to search for strings that
 looks like manpages with a regular expression."
   (save-excursion
-    (let ((end (window-end))
+    (let ((end (window-end nil t))
           (pt (window-start))
           candidates)
       (while (and (setq pt (next-property-change pt))


### PR DESCRIPTION
This PR addresses an issue I am having where `ace-link-man` does not collect all
the links and displays the `avy-background` only partway through the window.