### PR TITLE
Fix ace-link-mu4e for the default gnus viewer

### DIFF
--- a/ace-link.el
+++ b/ace-link.el
@@ -532,13 +532,13 @@ consider mu4e’s links."
 (defun ace-link-mu4e ()
   "Open a visible link in an `mu4e-view-mode' buffer."
   (interactive)
-  (if (bound-and-true-p mu4e-view-use-gnus)
-      (ace-link-gnus)
-    (let ((pt (avy-with ace-link-mu4e
-                (avy-process
-                 (mapcar #'cdr (ace-link--email-view-html-collect t))
-                 (avy--style-fn avy-style)))))
-      (ace-link--mu4e-action pt))))
+  (if (bound-and-true-p mu4e-view-use-old)
+      (let ((pt (avy-with ace-link-mu4e
+                  (avy-process
+                   (mapcar #'cdr (ace-link--email-view-html-collect t))
+                   (avy--style-fn avy-style)))))
+        (ace-link--mu4e-action pt))
+    (ace-link-gnus)))
 
 (declare-function shr-browse-url "shr")
 (declare-function mu4e~view-browse-url-from-binding "ext:mu4e-view")


### PR DESCRIPTION
While until July 2021 [0], you had to use `mu4e-view-use-gnus`
to activate the gnus view. This variable is now obsolete
and the gnus view is the default.
If you explicitly want the old mu4e view, you have to set
the `mu4e-view-use-old` variable to non-Nil.

[0] https://github.com/djcb/mu/blob/61a00df19721df31b1a32049480a70888032d5d7/NEWS.org#mu4e-2