### PR TITLE
Revert "ace-link.el (ace-link-commit): Add"

### DIFF
--- a/ace-link.el
+++ b/ace-link.el
@@ -90,8 +90,6 @@
          (ace-link-indium-inspector))
         ((eq major-mode 'indium-debugger-frames-mode)
          (ace-link-indium-debugger-frames))
-        ((eq major-mode 'magit-commit-mode)
-         (ace-link-commit))
         ((eq major-mode 'cider-inspector-mode)
          (ace-link-cider-inspector))
         ((and ace-link-fallback-function
@@ -182,38 +180,6 @@
         (setq skip (text-property-any (point) (window-end)
                                       'button nil))))
     (nreverse candidates)))
-
-;;* `ace-link-commit'
-(defvar ivy-ffap-url-functions)
-(defvar ffap-url-fetcher)
-(declare-function magit-goto-next-section "ext:magit")
-(declare-function magit-current-section "ext:magit")
-(declare-function magit-section-end "ext:magit")
-
-(defun ace-link-commit ()
-  "Open an issue link in the browser."
-  (interactive)
-  (require 'counsel)
-  (require 'ffap)
-  (let* ((pts (save-excursion
-                (goto-char (point-min))
-                (when (eq major-mode 'magit-commit-mode)
-                  (magit-goto-next-section))
-                (let ((cands nil)
-                      (end (if (eq major-mode 'magit-commit-mode)
-                               (magit-section-end (magit-current-section))
-                             (point-max))))
-                  (while (re-search-forward "#\\([0-9]+\\)" end t)
-                    (push (match-beginning 0) cands))
-                  (nreverse cands))))
-         (_pt (avy-with ace-link-commit
-               (avy-process pts)))
-         (url (cl-reduce
-               (lambda (a b)
-                 (or a (funcall b)))
-               ivy-ffap-url-functions
-               :initial-value nil)))
-    (funcall ffap-url-fetcher url)))
 
 ;;* `ace-link-man'
 ;;;###autoload


### PR DESCRIPTION
This reverts commit 483d0ea9d1e13884f13e54093b41082884325878. The
major-mode named `magit-commit-mode` has been renamed in the magit to
`magit-revision-mode` in 2014 in
df088b28fa4296b0cc9d72f6b42cc42d232c0150:

  rename magit-commit-mode to magit-revision-mode

Also, the code in `ace-link-commit` uses functions that don't exist
anymore such as `magit-goto-next-section' and `magit-section-end'.

Instead of fixing all of that, I decided to get rid of the code that
no one is using anyway.